### PR TITLE
Fix: Menu picker button mislabeled.

### DIFF
--- a/app/modules/editor/global/templates/partials/part_editorCommon.hbs
+++ b/app/modules/editor/global/templates/partials/part_editorCommon.hbs
@@ -53,7 +53,7 @@
   <div class="sidebar-row">
     <button class="editor-common-sidebar-menusettings">
       <span class="editor-common-sidebar-menusettings-inner">
-        <i class="fa fa-chevron-right primary-color"/></i>{{ t 'app.themeeditor'}}
+        <i class="fa fa-chevron-right primary-color"/></i>{{ t 'app.editorselectmenu'}}
       </span>
     </button>
   </div>


### PR DESCRIPTION
Requires (https://github.com/adapt-security/adapt-authoring-langpack-en/pulls)
Fixes (#208)

Menu picker button mislabeled.