### PR TITLE
Fix: Reload editor data and refresh view on copy/paste (fixes #192)

### DIFF
--- a/app/modules/editor/global/views/editorView.js
+++ b/app/modules/editor/global/views/editorView.js
@@ -221,7 +221,9 @@ define(function(require) {
           Origin.editor.clipboardId = null;
           Origin.trigger('editorView:menuView:addItem', new ContentObjectModel(newData))
           Origin.trigger(`editorView:pasted:${_parentId}`, newData);
-          Origin.trigger(`editorView:refreshView`);
+          Origin.trigger('editor:refreshData', () => {
+            Origin.trigger(`editorView:refreshView`);
+          });
         },
         fail: ({ message }) => {
           Origin.Notify.alert({ type: 'error', text: `${Origin.l10n.t('app.errorpaste')}${message ? `\n\n${message}` : ''}` });


### PR DESCRIPTION
#192 

Note: issue observed while working on #235 (with same solution)

### Fix
* Reload editor data and refresh view on copy/paste