### PR TITLE
Fix: CKEditor stripping out needed HTML attributes (#216)

### DIFF
--- a/app/core/models/contentModel.js
+++ b/app/core/models/contentModel.js
@@ -18,7 +18,7 @@ define(function(require) {
       return JSON.stringify(this);
     },
     pruneAttributes: function() {
-      if(this.attributelacklist) this.attributeBlacklist.forEach(this.unset);
+      if(this.attributeBlacklist) this.attributeBlacklist.forEach(this.unset);
     }
   });
 

--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -36,7 +36,8 @@
         },
         "extraAllowedContent": {
           "description": "Additional allowed content rules",
-          "type": "string"
+          "type": "string",
+          "default": "aside dd dt dl figcaption figure menu a abbr b bdi bdo cite code data dfn kbd mark q rp rt ruby samp small span time var wbr *(*)"
         },
         "textStyles": {
           "description": "Custom block and inline styles which can be applied to content in the editor",


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#216 

[//]: # (Delete as appropriate)
### Fix
* CKEditor stripping out needed HTML attributes (#216)

