### PR TITLE
Fix: fetch regular expression should only select rel='next' (fixes #275)

### DIFF
--- a/app/core/collections/apiCollection.js
+++ b/app/core/collections/apiCollection.js
@@ -45,11 +45,14 @@ define(['backbone', 'underscore'], function(Backbone, _) {
               memo.push(...d.models);
               const link = res.xhr.getResponseHeader('Link');
               if(link) {
-                const nextUrlMatch = link.match(/<(.+)>; rel="next",/);
-                if(nextUrlMatch) return resolve(_fetch(nextUrlMatch[1], memo));
+                const nextUrlMatch = link.match(/<[^>]*>; rel="next"/);
+                if(nextUrlMatch) {
+                  const nextUrl = nextUrlMatch[0].match(/<(.*)>/);
+                  return resolve(_fetch(nextUrl[1], memo));
+                }
               }
               resolve(memo);
-            }, 
+            },
             error: console.log
           }, options));
         });


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#275 

[//]: # (Delete as appropriate)
### Fix
* fetch regular expression only selecting rel='next' (fixes #275)


