### PR TITLE
Fix: search by name (fixes #289)

### DIFF
--- a/app/modules/projects/views/projectsSidebarView.js
+++ b/app/modules/projects/views/projectsSidebarView.js
@@ -20,8 +20,9 @@ define(function(require) {
       'paste .projects-sidebar-filter-search-input': 'onPaste'
     },
 
-    preinitialize: function() {
+    initialize: function() {
       this.debouncedFilterProjectsByTitle = _.debounce(this.filterProjectsByTitle.bind(this), 1000);
+      return SidebarItemView.prototype.initialize.apply(this, arguments);
     },
 
     postRender: function() {


### PR DESCRIPTION
#289 

### Fix
* Search by name (was using API unavailable in Backbone 1.1.0)