### PR TITLE
Fix for page not re-rendering on changes

### DIFF
--- a/app/modules/editor/contentObject/views/editorPageComponentPasteZoneView.js
+++ b/app/modules/editor/contentObject/views/editorPageComponentPasteZoneView.js
@@ -12,6 +12,7 @@ define(function(require){
     preRender: function () {
       this.listenTo(this.model, 'destroy', this.remove);
       this.listenTo(Origin, 'editorView:removeSubViews editorPageView:removePageSubViews', this.remove);
+      this.listenTo(Origin, 'editor:dataLoaded', () => Origin.trigger('editorView:renderPage'))
     },
 
     postRender: function () {
@@ -32,7 +33,7 @@ define(function(require){
               _layout: (!isLeft && !isRight) ? 'full' : (isLeft ? 'left' : 'right'),
               _parentId: view.model.get('_parentId')
             },
-            success: () => Origin.trigger('editorView:renderPage'),
+            success: () => Origin.trigger('editor:refreshData'),
             error: ({ responseJSON }) => Origin.Notify.alert({ type: 'error', text: responseJSON.message })
           });
         }

--- a/app/modules/editor/contentObject/views/editorPageComponentView.js
+++ b/app/modules/editor/contentObject/views/editorPageComponentView.js
@@ -16,6 +16,7 @@ define(['../../global/views/editorOriginView', 'core/origin'], function(EditorOr
     preRender: function() {
       this.$el.addClass('component-' + this.model.get('_layout'));
       this.listenTo(Origin, 'editorView:removeSubViews editorPageView:removePageSubViews', this.remove);
+      this.listenTo(Origin, 'editor:dataLoaded', () => Origin.trigger('editorView:renderPage'))
       this.on({
         'contextMenu:component:edit': this.loadComponentEdit,
         'contextMenu:component:copy': this.onCopy,
@@ -189,7 +190,7 @@ define(['../../global/views/editorOriginView', 'core/origin'], function(EditorOr
         type: 'PATCH',
         url:`api/content/${id}`,
         data: { _layout: layout },
-        success: () => Origin.trigger('editorView:renderPage'),
+        success: () => Origin.trigger('editor:refreshData'),
         error: jqXHR => Origin.Notify.alert({ type: 'error', text: jqXHR.responseJSON.message })
       });
     }

--- a/app/modules/editor/global/views/editorPasteZoneView.js
+++ b/app/modules/editor/global/views/editorPasteZoneView.js
@@ -13,6 +13,7 @@ define(function(require){
     preRender: function() {
       this.listenTo(this.model, 'destroy', this.remove);
       this.listenTo(Origin, 'editorView:removeSubViews editorPageView:removePageSubViews', this.remove);
+      this.listenTo(Origin, 'editor:dataLoaded', () => Origin.trigger('editorView:renderPage'))
     },
 
     postRender: function () {
@@ -53,7 +54,7 @@ define(function(require){
           Origin.trigger(eventPrefix + droppedOnId);
           // notify the old parent that the child's gone
           if(droppedOnId !== _parentId) Origin.trigger(eventPrefix + _parentId);
-          Origin.trigger('editorView:renderPage');
+          Origin.trigger('editor:refreshData');
         },
         error: function(jqXHR) {
           Origin.Notify.alert({ type: 'error', text: jqXHR.responseJSON.message });


### PR DESCRIPTION
Changing component layout and moving items with drag and drop now triggers a data reload and re-render.