### PR TITLE
Fix: Incorrect asset duration display in template (fixes #350)

### DIFF
--- a/app/modules/assetManagement/templates/assetManagementPreview.hbs
+++ b/app/modules/assetManagement/templates/assetManagementPreview.hbs
@@ -25,7 +25,7 @@
   <div class="asset-size">{{t 'app.assetsize'}}: {{{bytesToSize size}}}</div>
 
   {{#if duration}}
-    <div class="asset-duration break">{{t 'app.assetduration'}}: {{{formatDuration metadata.duration}}}</div>
+    <div class="asset-duration break">{{t 'app.assetduration'}}: {{{formatDuration duration}}}</div>
   {{/if}}
 
   {{#if resolution}}


### PR DESCRIPTION
Fixes #350

[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#350

[//]: # (Delete as appropriate)
### Fix
* Fixes reference to duration field
