### PR TITLE
Update: Change editor:type event to allow custom plugin routing (fixes #353)

### DIFF
--- a/app/modules/editor/index.js
+++ b/app/modules/editor/index.js
@@ -43,7 +43,7 @@ define([
         type = 'course';
         break;
     }
-    Origin.trigger(`editor:${type}`, {
+    Origin.trigger(`editor:${type ?? route2}`, {
       type: route2,
       id: Origin.location.route3,
       action: Origin.location.route4


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#353 

[//]: # (Delete as appropriate)
### Update
* Changes the event to fall back to `editor:route2` when the type cannot be determined to allow use in custom UI plugins

