### PR TITLE
Update: Refactor plugin loading to use pluginsDirs (fixes #355)

### DIFF
--- a/lib/JavaScriptTask.js
+++ b/lib/JavaScriptTask.js
@@ -41,6 +41,7 @@ export default class JavaScriptTask {
       out: path.join(buildDir, 'js', 'adapt.min.js'),
       modulesGlob: 'node_modules/adapt-authoring-ui/app/modules/*/index.js',
       pluginsGlob: 'node_modules/adapt-authoring-*/ui-plugins/*/index.js',
+      pluginsDirs: uiPlugins,
       pluginsOrder: files => files,
       external: {
         jquery: 'empty:',
@@ -202,7 +203,7 @@ export default class JavaScriptTask {
       }
     })
 
-    const plugins = globSync(this.options.pluginsGlob).map(entry => {
+    const plugins = this.options.pluginsDirs.map(entry => {
       return {
         name: path.basename(path.dirname(entry)),
         main: path.basename(entry),


### PR DESCRIPTION
Fixes #355

[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)

[//]: # (Delete as appropriate)
### Update
* Replace hard-coded reference to UI plugin dir name in favour of the dir registered by the plugin itself


