### PR TITLE
Fix: Broken query string parsing in user reset flow (fixes #393)

### DIFF
--- a/app/modules/user/index.js
+++ b/app/modules/user/index.js
@@ -25,7 +25,7 @@ define(function(require) {
     if(location.indexOf('reset') === 0) { // hack fix this
       $('body').removeClass(`location-${location}`);
       try {
-        query = parseQueryString(location);
+        query = parseQueryString(window.location.href);
       } catch(e) {}
       location = 'reset';
       $('body').addClass(`location-${location}`);


### PR DESCRIPTION
Fixes #393

### Fix
* Changed parseQueryString to use window.location.href instead of the location variable in the password reset flow to correctly parse query parameters

### Testing
1. Navigate to the password reset page
2. Verify that query string parameters are correctly parsed from the URL