### PR TITLE
Fix: Add noAuth flag to password reset API call (fixes #395)

### DIFF
--- a/app/modules/user/views/resetPasswordView.js
+++ b/app/modules/user/views/resetPasswordView.js
@@ -50,7 +50,7 @@ define(function(require) {
         return this.handleValidationError(this.model, [Origin.l10n.t('app.passwordnomatcherror')]);
       }
       try {
-        await $.post('api/auth/local/changepass', { password, email: this.model.get('email'), token: this.model.get('token') });
+        await $.post('api/auth/local/changepass', { password, email: this.model.get('email'), token: this.model.get('token'), noAuth: true });
         this.$('.form-reset-password').addClass('display-none');
         this.$('.reset-introduction').addClass('display-none');
         this.$('.message .success').removeClass('display-none');


### PR DESCRIPTION
Fixes #395

### Fix
* Added noAuth: true parameter to the changepass API request to bypass authentication requirements during the password reset flow

### Testing
1. Navigate to the password reset page
2. Request a password reset and follow the email link
3. Enter a new password and confirm
4. Verify the password change completes successfully without authentication errors