### PR TITLE
Fix: Document dynamic lang string keys for at-langcheck tool (fixes #399)

### DIFF
--- a/app/modules/editor/contentObject/views/editorMenuItemView.js
+++ b/app/modules/editor/contentObject/views/editorMenuItemView.js
@@ -81,11 +81,19 @@ define(function(require){
       this.listenToOnce(Origin, 'editorView:cancelRemoveItem:'+ this.model.get('_id'), this.cancelDeleteItem);
 
       var self = this;
+      const type = this.model.get('_type')
 
+      /**
+       * Lang string keys used (for at-langcheck):
+       * - app.confirmdeletemenu
+       * - app.confirmdeletepage
+       * - app.deleteitemmenu
+       * - app.deleteitempage
+       */
       Origin.Notify.confirm({
         type: 'warning',
-        title: Origin.l10n.t('app.deleteitem'+ this.model.get('_type')),
-        text: Origin.l10n.t('app.confirmdelete' + this.model.get('_type')) + '<br/><br/>' + Origin.l10n.t('app.confirmdeletewarning' + this.model.get('_type')),
+        title: Origin.l10n.t('app.deleteitem' + type),
+        text: `${Origin.l10n.t('app.confirmdelete' + type)}<br/><br/>${Origin.l10n.t('app.confirmdeletewarning' + type)}`,
         callback: result => self.onConfirmRemovePopup(result.isConfirmed)
       });
     },

--- a/app/modules/frameworkImport/templates/frameworkImportSummary.hbs
+++ b/app/modules/frameworkImport/templates/frameworkImportSummary.hbs
@@ -9,6 +9,22 @@
   <div class="inner">
     <p>Find below a summary of the course being imported.</p>
     <div class="statusReport">
+      {{! Lang string keys used (for at-langcheck):
+        - app.import.status.ASSETS_IMPORTED_SUCCESSFULLY
+        - app.import.status.CONTENT_IMPORTED
+        - app.import.status.INSTALL_PLUGIN
+        - app.import.status.INSTALLED
+        - app.import.status.INVALID
+        - app.import.status.INVALID_PLUGIN_VERSION
+        - app.import.status.MANAGED_PLUGIN_UPDATE_DISABLED
+        - app.import.status.MIGRATE_CONTENT
+        - app.import.status.PLUGIN_INSTALL_MIGRATING
+        - app.import.status.NO_CHANGE
+        - app.import.status.OLDER
+        - app.import.status.TAGS_IMPORTED
+        - app.import.status.UPDATE_BLOCKED
+        - app.import.status.UPDATED
+      }}
       {{> part_frameworkImportStatusMessages type='error' messages=statusReport.error heading='Errors'}}
       {{> part_frameworkImportStatusMessages type='warn' messages=statusReport.warn heading='Warnings'}}
       {{> part_frameworkImportStatusMessages type='info' messages=statusReport.info heading='Information'}}


### PR DESCRIPTION
Fixes #399

### Fix
* Add lang string key comments to document dynamically constructed keys

### Testing
1. Run at-langcheck CI workflow and verify no false positives for the documented keys