### PR TITLE
Fix: Add max-height to swal2-html-container (fixes #410)

### DIFF
--- a/app/modules/notify/plugins/alert/less/alert.less
+++ b/app/modules/notify/plugins/alert/less/alert.less
@@ -30,6 +30,9 @@
       font-size: 115%;
     }
   }
+  .swal2-html-container {
+    max-height: 300px;
+  }
   .swal2-icon {
     &.swal2-error {
       border-color: @alert-color;


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#410 

[//]: # (Delete as appropriate)
### Fix
* Limit SweetAlert max-height to allow for very long texts