### PR TITLE
Fix: Apply audit fixes (fixes #443)

### DIFF
--- a/lib/UiBuild.js
+++ b/lib/UiBuild.js
@@ -190,9 +190,9 @@ class UiBuild {
     this.addWatch(this.Globs.hbs, this.compileHandlebars.bind(this))
     this.addWatch(this.Globs.less, this.compileLess.bind(this))
     this.addWatch(this.Globs.js, this.compileJs.bind(this))
-    this.addWatch(this.Globs.assets, this.onChanged('assets', this.Paths.OutputAssets))
+    this.addWatch(this.Globs.assets, this.onChanged('assets', this.Paths.OutputDirs.assets))
     this.addWatch(this.Globs.required, this.onChanged('required', this.Paths.Output))
-    this.addWatch(this.Globs.libraries, this.onChanged('libraries', this.Paths.OutputLibraries))
+    this.addWatch(this.Globs.libraries, this.onChanged('libraries', this.Paths.OutputDirs.libraries))
   }
 
   async run () {


### PR DESCRIPTION
### Fix
* Reference `Paths.OutputDirs.assets` and `Paths.OutputDirs.libraries` instead of undefined `Paths.OutputAssets` and `Paths.OutputLibraries` in watch mode

### Testing
1. Verify asset and library file changes are propagated to build output in watch mode