### PR TITLE
Update: Read/write themeVariables from config instead of course

### DIFF
--- a/app/modules/editor/themeEditor/views/editorThemingView.js
+++ b/app/modules/editor/themeEditor/views/editorThemingView.js
@@ -33,7 +33,7 @@ define(function(require) {
     },
 
     initData: async function() {
-      this.model = new Backbone.Model(Origin.editor.data.course.get('themeVariables'));
+      this.model = new Backbone.Model(Origin.editor.data.config.get('themeVariables'));
       this.themes = new ContentPluginCollection(undefined, { type: 'theme' });
       this.presets = new PresetCollection();
       
@@ -216,7 +216,7 @@ define(function(require) {
       return new Promise((resolve, reject) => {
         if(!this.form) return resolve();
         this.form.commit();
-        Origin.editor.data.course.save({ themeVariables: this.model.attributes }, { error: () => reject(), success: () => resolve() });
+        Origin.editor.data.config.save({ themeVariables: this.model.attributes }, { error: () => reject(), success: () => resolve() });
       });
     },
 


### PR DESCRIPTION
### Update
* Theme editor now reads `themeVariables` from `Origin.editor.data.config` instead of `Origin.editor.data.course`
* Theme editor now saves `themeVariables` to the config model instead of the course model

### Testing
1. Start with `npm run dev` from `adapt-authoring/`
2. Open theme editor — verify theme variables load correctly from config
3. Modify theme variables and save — verify changes are saved to config record in MongoDB
4. Verify no theme data remains on the course record after saving

Fixes #449
Depends on adapt-security/adapt-authoring-coursetheme#55
Related framework PR: adaptlearning/adapt_framework#3578