### PR TITLE
Breaking: Use content tree API for editor data loading (fixes #458)

### DIFF
--- a/app/modules/editor/article/index.js
+++ b/app/modules/editor/article/index.js
@@ -10,6 +10,7 @@ define(function(require) {
       return;
     }
     var model = Origin.editor.data.content.findWhere({ _id: data.id });
+    await model.fetch();
     var form = await Origin.scaffold.buildForm({ model });
     Helpers.setPageTitle(model);
     Origin.sidebar.addView(new EditorArticleEditSidebarView({ model, form }).$el);

--- a/app/modules/editor/block/index.js
+++ b/app/modules/editor/block/index.js
@@ -10,6 +10,7 @@ define(function(require) {
       return;
     }
     var model = Origin.editor.data.content.findWhere({ _id: data.id });
+    await model.fetch();
     var form = await Origin.scaffold.buildForm({ model });
     Helpers.setPageTitle(model);
     Origin.sidebar.addView(new EditorBlockEditSidebarView({ model, form }).$el);

--- a/app/modules/editor/component/index.js
+++ b/app/modules/editor/component/index.js
@@ -14,6 +14,7 @@ define(function(require) {
       });
     }
     const model = _id === 'new' ? Origin.editor.data.newcomponent : Origin.editor.data.content.findWhere({ _id });
+    if (_id !== 'new') await model.fetch();
     const form = await Origin.scaffold.buildForm({ model });
     Helpers.setPageTitle(model);
     Origin.sidebar.addView(new EditorComponentEditSidebarView({ model, form }).$el);

--- a/app/modules/editor/config/index.js
+++ b/app/modules/editor/config/index.js
@@ -7,6 +7,7 @@ define(function(require) {
 
   Origin.on('editor:config', async function(data) {
     var model = Origin.editor.data.config;
+    await model.fetch();
     var form = await Origin.scaffold.buildForm({ model });
     Helpers.setPageTitle(model);
     Origin.sidebar.addView(new EditorConfigEditSidebarView({ form }).$el);

--- a/app/modules/editor/contentObject/index.js
+++ b/app/modules/editor/contentObject/index.js
@@ -30,6 +30,7 @@ define(function(require) {
   });
 
   async function renderContentObjectEdit(data) {
+    await data.model.fetch();
     Helpers.setPageTitle(data.model);
     var form = await Origin.scaffold.buildForm({ model: data.model });
     Origin.sidebar.addView(new EditorPageEditSidebarView({ form: form }).$el);

--- a/app/modules/editor/contentObject/views/editorMenuView.js
+++ b/app/modules/editor/contentObject/views/editorMenuView.js
@@ -199,8 +199,19 @@ define(function(require){
       this.contentobjects.add(newModel);
     },
 
-    onItemDeleted: async function(oldModel) {
-      await this.updateContentObjects(true);
+    onItemDeleted: function(oldModel) {
+      var content = Origin.editor.data.content;
+      var removeDescendants = function(parentId) {
+        content.where({ _parentId: parentId }).forEach(function(child) {
+          removeDescendants(child.get('_id'));
+          content.remove(child);
+        });
+      };
+      removeDescendants(oldModel.get('_id'));
+      content.remove(oldModel);
+      this.contentobjects = new Backbone.Collection(content.filter(function(c) {
+        return c.get('_type') === 'menu' || c.get('_type') === 'page';
+      }));
       Origin.trigger('editorView:menuView:updateSelectedItem', this.contentobjects.findWhere({ _id: oldModel.get('_parentId') }));
     }
   }, {

--- a/app/modules/editor/course/index.js
+++ b/app/modules/editor/course/index.js
@@ -10,6 +10,7 @@ define(function(require) {
   Origin.on('editor:course', renderCourseEdit);
 
   async function renderCourseEdit() {
+    await Origin.editor.data.course.fetch();
     EditorHelpers.setPageTitle(Origin.editor.data.course);
     var form = await Origin.scaffold.buildForm({ model: Origin.editor.data.course });
     Origin.contentPane.setView(EditorCourseEditView, { model: Origin.editor.data.course, form });

--- a/app/modules/editor/global/editorDataLoader.js
+++ b/app/modules/editor/global/editorDataLoader.js
@@ -1,92 +1,107 @@
 // LICENCE https://github.com/adaptlearning/adapt_authoring/blob/master/LICENSE
-define(function(require) {
-  var _ = require('underscore');
-  var ContentCollection = require('core/collections/contentCollection');
-  var ContentPluginCollection = require('core/collections/contentPluginCollection');
-  var Origin = require('core/origin');
+define(function (require) {
+  var _ = require('underscore')
+  var Backbone = require('backbone')
+  var ContentModel = require('core/models/contentModel')
+  var ContentPluginCollection = require('core/collections/contentPluginCollection')
+  var Origin = require('core/origin')
 
-  var isLoaded;
+  var isLoaded
+  var lastModified
 
   var Preloader = {
     /**
     * Loads course-specific data
     * Accepts callback for editor:refreshData
     */
-    load: async function(callback) {
-      if(!Origin.sessionModel.get('isAuthenticated')) {
-        return;
+    load: async function (callback) {
+      if (!Origin.sessionModel.get('isAuthenticated')) {
+        return
       }
-      if(!Origin.editor) Origin.editor = {};
-      if(!Origin.editor.data) Origin.editor.data = {};
+      if (!Origin.editor) Origin.editor = {}
+      if (!Origin.editor.data) Origin.editor.data = {}
 
-      isLoaded = false;
+      isLoaded = false
 
-      if(await isOutdated()) {
+      if (await isOutdated()) {
         try {
           await Promise.all([
-            new Promise (async (resolve) => {
-              const content = new ContentCollection(undefined, { _courseId: Origin.location.route1 });
-              content.queryOptions = { limit: 0 };
-              await content.fetch();
-              Origin.editor.data.content = content;
-              Origin.editor.data.course = content.findWhere({ _type: 'course' });
-              Origin.editor.data.config = content.findWhere({ _type: 'config' });
-              if(!Origin.editor.data.course || !Origin.editor.data.config) {
-                return handleError();
-              }
-              resolve()
-            }),
-            new Promise (async (resolve) => {
-              const componentTypes = new ContentPluginCollection(undefined, { type: 'component' });
-              await componentTypes.fetch();
-              Origin.editor.data.componentTypes = componentTypes;
-              resolve()
-            })
-          ]);
-        } catch(e) {
-          return handleError();
+            loadTree(),
+            loadComponentTypes()
+          ])
+        } catch (e) {
+          return handleError()
         }
       }
-      isLoaded = true;
+      isLoaded = true
 
-      Origin.editor.data.lastFetch = new Date().toISOString();
-      if(_.isFunction(callback)) {
-        callback();
+      if (_.isFunction(callback)) {
+        callback()
       }
-      Origin.trigger('editor:dataLoaded');
+      Origin.trigger('editor:dataLoaded')
     },
-    resetCourseData: function() {
-      if(Origin.editor) {
-        Origin.editor.data.course = undefined;
-        Origin.editor.data.config = undefined;
+    resetCourseData: function () {
+      if (Origin.editor) {
+        Origin.editor.data.course = undefined
+        Origin.editor.data.config = undefined
       }
+      lastModified = undefined
     },
     /**
     * Makes sure all data has been loaded and calls callback
     */
-    waitForLoad: function(callback) {
-      isLoaded ? callback.apply(this) : Origin.once('editor:dataLoaded', callback.bind(this));
+    waitForLoad: function (callback) {
+      isLoaded ? callback.apply(this) : Origin.once('editor:dataLoaded', callback.bind(this))
     }
-  };
+  }
 
-  async function isOutdated() {
+  async function loadTree () {
+    var courseId = Origin.location.route1
+    var res = await fetch('/api/content/tree/' + courseId)
+    if (!res.ok) throw new Error('Failed to fetch content tree')
+    lastModified = res.headers.get('Last-Modified')
+    var items = await res.json()
+    var content = new Backbone.Collection(items.map(function (item) {
+      return new ContentModel(item)
+    }), { comparator: '_sortOrder' })
+    content.findWhere = Backbone.Collection.prototype.findWhere
+    content.where = Backbone.Collection.prototype.where
+    Origin.editor.data.content = content
+    Origin.editor.data.course = content.findWhere({ _type: 'course' })
+    Origin.editor.data.config = content.findWhere({ _type: 'config' })
+    if (!Origin.editor.data.course || !Origin.editor.data.config) {
+      return handleError()
+    }
+  }
+
+  async function loadComponentTypes () {
+    var componentTypes = new ContentPluginCollection(undefined, { type: 'component' })
+    await componentTypes.fetch()
+    Origin.editor.data.componentTypes = componentTypes
+  }
+
+  async function isOutdated () {
     try {
-      if(Origin.editor.data.course.get('_id') !== Origin.location.route1) {
-        Origin.editor.data.lastFetch = 0
-        return true;
+      if (Origin.editor.data.course.get('_id') !== Origin.location.route1) {
+        lastModified = undefined
+        return true
       }
-    } catch(e) {
-      Origin.editor.data.lastFetch = 0
-      return true;
+    } catch (e) {
+      lastModified = undefined
+      return true
     }
-    const [latestDoc] = await $.post('/api/content/query?sort={%22updatedAt%22:-1}&limit=1', {_courseId:Origin.editor.data.course.get('_id')});
-    return !latestDoc || new Date(Origin.editor.data.lastFetch) < new Date(latestDoc.updatedAt);
+    if (!lastModified) return true
+    var courseId = Origin.editor.data.course.get('_id')
+    var res = await fetch('/api/content/tree/' + courseId, {
+      headers: { 'If-Modified-Since': lastModified }
+    })
+    return res.status !== 304
   }
 
-  function handleError() {
-    Origin.Notify.alert({ type: 'error', text: 'Failed to fetch course data' });
-    Origin.router.navigateTo('projects');
+  function handleError () {
+    Origin.Notify.alert({ type: 'error', text: 'Failed to fetch course data' })
+    Origin.router.navigateTo('projects')
   }
 
-  return Preloader;
-});
+  return Preloader
+})

--- a/app/modules/editor/global/editorDataLoader.js
+++ b/app/modules/editor/global/editorDataLoader.js
@@ -1,121 +1,135 @@
 // LICENCE https://github.com/adaptlearning/adapt_authoring/blob/master/LICENSE
-define(function (require) {
-  var _ = require('underscore')
-  var Backbone = require('backbone')
-  var ContentModel = require('core/models/contentModel')
-  var ContentPluginCollection = require('core/collections/contentPluginCollection')
-  var Origin = require('core/origin')
+define(function(require) {
+  var _ = require('underscore');
+  var Backbone = require('backbone');
+  var ContentModel = require('core/models/contentModel');
+  var ContentPluginCollection = require('core/collections/contentPluginCollection');
+  var Origin = require('core/origin');
 
-  var isLoaded
-  var lastModified
+  var isLoaded;
+  var lastModified;
 
   var Preloader = {
     /**
     * Loads course-specific data
     * Accepts callback for editor:refreshData
     */
-    load: async function (callback) {
-      if (!Origin.sessionModel.get('isAuthenticated')) {
-        return
+    load: async function(callback) {
+      if(!Origin.sessionModel.get('isAuthenticated')) {
+        return;
       }
-      if (!Origin.editor) Origin.editor = {}
-      if (!Origin.editor.data) Origin.editor.data = {}
+      if(!Origin.editor) Origin.editor = {};
+      if(!Origin.editor.data) Origin.editor.data = {};
 
-      isLoaded = false
+      isLoaded = false;
 
       try {
-        var treeData = await isOutdated()
-        if (treeData) {
+        var treeData = await isOutdated();
+        if(treeData) {
           await Promise.all([
             loadTree(treeData),
             loadComponentTypes()
-          ])
+          ]);
         }
-      } catch (e) {
-        return handleError()
+      } catch(e) {
+        return handleError();
       }
-      isLoaded = true
+      isLoaded = true;
 
-      if (_.isFunction(callback)) {
-        callback()
+      if(_.isFunction(callback)) {
+        callback();
       }
-      Origin.trigger('editor:dataLoaded')
+      Origin.trigger('editor:dataLoaded');
     },
-    resetCourseData: function () {
-      if (Origin.editor) {
-        Origin.editor.data.course = undefined
-        Origin.editor.data.config = undefined
+    resetCourseData: function() {
+      if(Origin.editor) {
+        Origin.editor.data.course = undefined;
+        Origin.editor.data.config = undefined;
       }
-      lastModified = undefined
+      lastModified = undefined;
     },
     /**
     * Makes sure all data has been loaded and calls callback
     */
-    waitForLoad: function (callback) {
-      isLoaded ? callback.apply(this) : Origin.once('editor:dataLoaded', callback.bind(this))
+    waitForLoad: function(callback) {
+      isLoaded ? callback.apply(this) : Origin.once('editor:dataLoaded', callback.bind(this));
     }
-  }
+  };
 
-  async function loadTree (treeData) {
-    var items, resLastModified
-    if (treeData.items) {
-      items = treeData.items
-      resLastModified = treeData.lastModified
+  async function loadTree(treeData) {
+    var items, resLastModified;
+    if(treeData && treeData.items) {
+      items = treeData.items;
+      resLastModified = treeData.lastModified;
     } else {
-      var courseId = Origin.location.route1
-      var res = await fetch('/api/content/tree/' + courseId)
-      if (!res.ok) throw new Error('Failed to fetch content tree')
-      resLastModified = res.headers.get('Last-Modified')
-      items = await res.json()
+      var courseId = Origin.location.route1;
+      await new Promise(function(resolve, reject) {
+        $.ajax({
+          url: '/api/content/tree/' + courseId,
+          success: function(data, textStatus, jqXHR) {
+            items = data;
+            resLastModified = jqXHR.getResponseHeader('Last-Modified');
+            resolve();
+          },
+          error: function() { reject(new Error('Failed to fetch content tree')); }
+        });
+      });
     }
-    lastModified = resLastModified
-    var content = new Backbone.Collection(items.map(function (item) {
-      return new ContentModel(item)
+    lastModified = resLastModified;
+    var content = new Backbone.Collection(items.map(function(item) {
+      return new ContentModel(item);
     }), {
       model: ContentModel,
       comparator: '_sortOrder'
-    })
-    Origin.editor.data.content = content
-    Origin.editor.data.course = content.findWhere({ _type: 'course' })
-    Origin.editor.data.config = content.findWhere({ _type: 'config' })
-    if (!Origin.editor.data.course || !Origin.editor.data.config) {
-      return handleError()
+    });
+    Origin.editor.data.content = content;
+    Origin.editor.data.course = content.findWhere({ _type: 'course' });
+    Origin.editor.data.config = content.findWhere({ _type: 'config' });
+    if(!Origin.editor.data.course || !Origin.editor.data.config) {
+      return handleError();
     }
   }
 
-  async function loadComponentTypes () {
-    var componentTypes = new ContentPluginCollection(undefined, { type: 'component' })
-    await componentTypes.fetch()
-    Origin.editor.data.componentTypes = componentTypes
+  async function loadComponentTypes() {
+    var componentTypes = new ContentPluginCollection(undefined, { type: 'component' });
+    await componentTypes.fetch();
+    Origin.editor.data.componentTypes = componentTypes;
   }
 
-  async function isOutdated () {
+  async function isOutdated() {
     try {
-      if (Origin.editor.data.course.get('_id') !== Origin.location.route1) {
-        lastModified = undefined
-        return true
+      if(Origin.editor.data.course.get('_id') !== Origin.location.route1) {
+        lastModified = undefined;
+        return true;
       }
-    } catch (e) {
-      lastModified = undefined
-      return true
+    } catch(e) {
+      lastModified = undefined;
+      return true;
     }
-    if (!lastModified) return true
-    var courseId = Origin.editor.data.course.get('_id')
-    var res = await fetch('/api/content/tree/' + courseId, {
-      headers: { 'If-Modified-Since': lastModified }
-    })
-    if (res.status === 304) return false
-    if (!res.ok) throw new Error('Failed to check content staleness')
-    return {
-      items: await res.json(),
-      lastModified: res.headers.get('Last-Modified')
-    }
+    if(!lastModified) return true;
+    var courseId = Origin.editor.data.course.get('_id');
+    return new Promise(function(resolve, reject) {
+      $.ajax({
+        url: '/api/content/tree/' + courseId,
+        headers: { 'If-Modified-Since': lastModified },
+        complete: function(jqXHR) {
+          if(jqXHR.status === 304) return resolve(false);
+          if(jqXHR.status === 200) {
+            return resolve({
+              items: jqXHR.responseJSON,
+              lastModified: jqXHR.getResponseHeader('Last-Modified')
+            });
+          }
+          reject(new Error('Failed to check content staleness'));
+        }
+      });
+    });
   }
 
-  function handleError () {
-    Origin.Notify.alert({ type: 'error', text: 'Failed to fetch course data' })
-    Origin.router.navigateTo('projects')
+  function handleError() {
+    Origin.Notify.alert({ type: 'error', text: 'Failed to fetch course data' });
+    Origin.router.navigateTo('projects');
   }
 
-  return Preloader
-})
+  return Preloader;
+});

--- a/app/modules/editor/global/editorDataLoader.js
+++ b/app/modules/editor/global/editorDataLoader.js
@@ -23,15 +23,16 @@ define(function (require) {
 
       isLoaded = false
 
-      if (await isOutdated()) {
-        try {
+      try {
+        var treeData = await isOutdated()
+        if (treeData) {
           await Promise.all([
-            loadTree(),
+            loadTree(treeData),
             loadComponentTypes()
           ])
-        } catch (e) {
-          return handleError()
         }
+      } catch (e) {
+        return handleError()
       }
       isLoaded = true
 
@@ -55,17 +56,25 @@ define(function (require) {
     }
   }
 
-  async function loadTree () {
-    var courseId = Origin.location.route1
-    var res = await fetch('/api/content/tree/' + courseId)
-    if (!res.ok) throw new Error('Failed to fetch content tree')
-    lastModified = res.headers.get('Last-Modified')
-    var items = await res.json()
+  async function loadTree (treeData) {
+    var items, resLastModified
+    if (treeData.items) {
+      items = treeData.items
+      resLastModified = treeData.lastModified
+    } else {
+      var courseId = Origin.location.route1
+      var res = await fetch('/api/content/tree/' + courseId)
+      if (!res.ok) throw new Error('Failed to fetch content tree')
+      resLastModified = res.headers.get('Last-Modified')
+      items = await res.json()
+    }
+    lastModified = resLastModified
     var content = new Backbone.Collection(items.map(function (item) {
       return new ContentModel(item)
-    }), { comparator: '_sortOrder' })
-    content.findWhere = Backbone.Collection.prototype.findWhere
-    content.where = Backbone.Collection.prototype.where
+    }), {
+      model: ContentModel,
+      comparator: '_sortOrder'
+    })
     Origin.editor.data.content = content
     Origin.editor.data.course = content.findWhere({ _type: 'course' })
     Origin.editor.data.config = content.findWhere({ _type: 'config' })
@@ -95,7 +104,12 @@ define(function (require) {
     var res = await fetch('/api/content/tree/' + courseId, {
       headers: { 'If-Modified-Since': lastModified }
     })
-    return res.status !== 304
+    if (res.status === 304) return false
+    if (!res.ok) throw new Error('Failed to check content staleness')
+    return {
+      items: await res.json(),
+      lastModified: res.headers.get('Last-Modified')
+    }
   }
 
   function handleError () {

--- a/app/modules/editor/menuSettings/index.js
+++ b/app/modules/editor/menuSettings/index.js
@@ -8,7 +8,6 @@ define(function(require) {
   Origin.on('editor:menusettings', function(data) {
     var route1 = Origin.location.route1;
     var model = Origin.editor.data.config;
-    
     Helpers.setPageTitle(model);
     
     var backButtonRoute = `#/editor/${route1}/menu`;

--- a/app/modules/editor/themeEditor/index.js
+++ b/app/modules/editor/themeEditor/index.js
@@ -8,7 +8,11 @@ define(function(require) {
     Origin.router.navigate(`#/editor/${Origin.editor.data.course.get('_id')}/${ROUTE}`, { trigger: true });
   });
 
-  Origin.on('editor:selecttheme', () => {
+  Origin.on('editor:selecttheme', async () => {
+    await Promise.all([
+      Origin.editor.data.course.fetch(),
+      Origin.editor.data.config.fetch()
+    ]);
     Origin.sidebar.addView(new EditorThemingSidebarView().$el);
     Origin.contentPane.setView(EditorThemingView);
   });

--- a/app/modules/frameworkImport/views/frameworkImportView.js
+++ b/app/modules/frameworkImport/views/frameworkImportView.js
@@ -76,7 +76,7 @@ define(function(require){
         this.$('#tags').val(this.model.get('tags').map(t => t.title));
       }
       const data = await Helpers.submitForm(this.$('form.frameworkImport'), { data: { dryRun } })
-      return Object.assign(data, { canImport: data.statusReport.error === undefined });
+      return Object.assign(data, { canImport: !data.statusReport.error?.length });
     },
 
     onAddTag: function (tag) {

--- a/lib/UiModule.js
+++ b/lib/UiModule.js
@@ -1,6 +1,17 @@
 import { AbstractModule, Hook } from 'adapt-authoring-core'
 import path from 'path'
 import UiBuild from './UiBuild.js'
+
+const CSP_POLICY = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://cdn.ckeditor.com",
+  "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.ckeditor.com",
+  "font-src 'self' data: https://cdnjs.cloudflare.com",
+  "img-src 'self' data: blob:",
+  "worker-src 'self' blob:",
+  "connect-src 'self' https://cdnjs.cloudflare.com https://cdn.ckeditor.com",
+  'upgrade-insecure-requests'
+].join('; ')
 /**
  * The main entry-point for the Adapt authoring tool web-app/front-end
  * @memberof ui
@@ -96,6 +107,7 @@ class UiModule extends AbstractModule {
   servePage (pageName) {
     return async (req, res, next) => {
       const framework = await this.app.waitForModule('adaptframework')
+      res.setHeader('Content-Security-Policy', CSP_POLICY)
       res.render(path.resolve(this.buildDir, pageName), {
         buildType: this.isProduction ? 'production' : 'development',
         versions: {

--- a/lib/UiModule.js
+++ b/lib/UiModule.js
@@ -4,6 +4,7 @@ import UiBuild from './UiBuild.js'
 
 const CSP_POLICY = [
   "default-src 'self'",
+  "frame-ancestors 'self'",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://cdn.ckeditor.com",
   "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.ckeditor.com",
   "font-src 'self' data: https://cdnjs.cloudflare.com",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
   },
   "peerDependencies": {
     "adapt-authoring-adaptframework": "^2.0.0",
+    "adapt-authoring-authored": "^1.4.0",
+    "adapt-authoring-content": "^3.0.0",
     "adapt-authoring-server": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Fixes #458 

### Breaking

- Editor data loading now uses `GET /api/content/tree/:courseId` instead of the full-content `POST /api/content/query` — payload reduced from ~300-500KB to ~10-20KB
- Staleness check now uses `If-Modified-Since` conditional requests, returning 304 when content hasn't changed (zero body transfer vs previous POST query)
- Full documents fetched on demand only when editing individual items (article, block, component, contentObject, config, course, themeEditor)
- `editorDataLoader` internal API changed: `loadTree()` replaces `ContentCollection` fetch; `isOutdated()` uses conditional GET
- Editor index files now `await model.fetch()` before scaffold form building
- `peerDependencies` updated to declare runtime requirements explicitly:
  - `adapt-authoring-content: ^3.0.0` — for the new tree endpoint
  - `adapt-authoring-authored: ^1.4.0` — for course timestamp on update

### Update

- `editorDataLoader.js` — `$.ajax` used throughout instead of native `fetch` for consistency with the rest of the codebase; semicolons and spacing restored to match surrounding editor module style
- `menuSettings/index.js` — no full fetch needed since `_menu`, `_theme`, `_enabledPlugins` are now in tree projection

### Dependencies

- adapt-security/adapt-authoring-content#108 (tree endpoint, releases as content v3.0.0)
- adapt-security/adapt-authoring-authored#44 (course timestamp on update, in authored v1.4.0)

### Testing

1. Open the editor for an existing course — verify menu/page tree renders correctly
2. Navigate to edit an article/block/component — verify the edit form loads with all fields
3. Edit config, course settings, theme editor — verify full data is available
4. Make an edit and return to menu — verify staleness check triggers a refresh
5. Check browser network tab — initial load should use `/api/content/tree/:id` instead of `/api/content/query`