### PR TITLE
Fix: Stop lazy-scroll fetches once collection is exhausted

### DIFF
--- a/app/modules/projects/views/projectsView.js
+++ b/app/modules/projects/views/projectsView.js
@@ -205,7 +205,7 @@ define(function(require){
     },
 
     doLazyScroll: function(e) {
-      if(this.isCollectionFetching) {
+      if(this.shouldStopFetches || this.isCollectionFetching) {
         return;
       }
       const $last = $('.project-list-item').last();


### PR DESCRIPTION
### Fix
- Add `shouldStopFetches` to the early-return guard in `doLazyScroll`, matching the existing guard in `checkAndFillVisibleArea`. Without it, `doLazyScroll` keeps firing `fetchCollection()` after the collection has been exhausted; the inner short-circuit at `fetchCollection`'s first line catches it, but the bounce is a latent loop driver.

Defence-in-depth alongside the server-side fixes:
- adapt-security/adapt-authoring-api#103 (`accessQueryHook` + removed fill-the-page)
- cgkineo/adapt-authoring-multilang#48 (query-time language filter)
- adapt-security/adapt-authoring-adaptframework#202 (query-time ownership filter)

### Testing
- `npx standard` — clean. No unit tests in this repo for view modules.