### PR TITLE
Fix: Persist heroImage removal in asset clear handler

### DIFF
--- a/app/modules/scaffold/views/scaffoldAssetView.js
+++ b/app/modules/scaffold/views/scaffoldAssetView.js
@@ -44,7 +44,9 @@ define([
 
     checkValueHasChanged: function() {
       var value = this.getValue();
-      if (this.key === 'heroImage') return this.saveModel({ heroImage: value });
+      // getValue() coerces a cleared field to undefined, which JSON.stringify drops from the
+      // request body; send an empty string so the cleared heroImage is actually persisted
+      if (this.key === 'heroImage') return this.saveModel({ heroImage: value || '' });
       if (Helpers.isAssetExternal(value)) return this.saveModel();
     },
 
@@ -112,8 +114,10 @@ define([
     onClearButtonClicked: function(event) {
       event.preventDefault();
 
-      this.checkValueHasChanged();
+      // clear the value before saving, otherwise checkValueHasChanged reads (and re-saves)
+      // the old value, leaving the removed asset in place
       this.setValue('');
+      this.checkValueHasChanged();
     },
 
     onExternalAssetButtonClicked: function(event) {


### PR DESCRIPTION
### Fixes adapt-security/adapt-authoring-content#130

### Fix
- `onClearButtonClicked` called `checkValueHasChanged()` **before** `setValue('')`, so it read and re-saved the *old* asset id rather than the cleared value. `getValue()` also coerces a cleared field to `undefined`, which `JSON.stringify` drops from the request body, so the server never receives the cleared field and the merge restores the previous value.
- Clear the value first, then save, and send an empty string for `heroImage` so a removed course preview image is actually deleted (and no longer reappears on reload).

### Testing
- Confirmed against the API that `heroImage` is cleared when sent `''` and silently restored when the field is omitted, so the root cause is the omitted/old value rather than the backend.
- After the change, clicking "Remove Asset" on the course preview image under project settings persists the removal; the default image is shown and the image no longer returns on reload.