### PR TITLE
Update: consume core branding/theme/image config vars (fixes #477)

### DIFF
--- a/app/core/helpers.js
+++ b/app/core/helpers.js
@@ -303,6 +303,10 @@ define(['handlebars', 'moment', 'core/origin'], function(Handlebars, Moment, Ori
       this.constants = Origin.constants;
       return '';
     },
+
+    constant: function(key) {
+      return Origin.constants[key];
+    },
     // Comparison operator (ifValueEquals left for compatibility)
     when: function (a, operator, b, block) {
       console.log(a, operator, b);

--- a/app/core/less/colours.less
+++ b/app/core/less/colours.less
@@ -24,6 +24,8 @@
 @tertiary-color:@adapt-tertiary-color;
 @quaternary-color:@adapt-quaternary-color;
 @white:@adapt-white;
+@logo-image: url('assets/adapt-learning-logo-white.png');
+@login-background-image: url('assets/login_bg.jpg');
 ///////////
 
 

--- a/app/core/less/sharedStyles.less
+++ b/app/core/less/sharedStyles.less
@@ -29,7 +29,7 @@
 }
 
 .no-ui {
-  background: url(assets/login_bg.jpg) no-repeat center center fixed;
+  background: @login-background-image no-repeat center center fixed;
   -webkit-background-size: cover;
   -moz-background-size: cover;
   -o-background-size: cover;

--- a/app/core/required/index.hbs
+++ b/app/core/required/index.hbs
@@ -2,7 +2,7 @@
 <html lang="en" data-adapt-framework-version="{{versions.adapt_framework}}" data-adapt-authoring-version="{{versions.adapt-authoring}}">
   <head>
     <title>{{productName}}</title>
-    <link rel="icon" type="image/png" href="/css/assets/favicon.png" />
+    <link rel="icon" href="{{favicon}}" />
     <link rel="stylesheet" href="/css/adapt.css" />
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5/42.0.0/ckeditor5.css">
@@ -24,7 +24,7 @@
       <div class="loading">
         <div class="loading-inner">
           <div class="loading-logo">
-              <img src="/css/assets/adapt-learning-logo-outline.png">
+              <img src="{{logo}}">
           </div>
           <div class="loading-anim">
             <div class="circle1"></div>

--- a/app/core/required/loading.hbs
+++ b/app/core/required/loading.hbs
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <title>{{productName}}</title>
-    <link rel="icon" type="image/png" href="css/assets/favicon.png"/>
+    <link rel="icon" href="{{favicon}}"/>
     <link rel="stylesheet" href="css/adapt.css"/>
     <meta http-equiv="cache-control" content="no-store, no-cache, must-revalidate"/>
     <meta http-equiv="Pragma" content="no-store, no-cache"/>
@@ -13,7 +13,7 @@
       <div class="loading">
         <div class="loading-inner">
           <div class="loading-logo">
-            <img src="css/assets/adapt-learning-logo-outline.png">
+            <img src="{{logo}}">
           </div>
           <div class="loading-anim">
             <div class="circle1"></div>

--- a/app/modules/appHeader/templates/appHeader.hbs
+++ b/app/modules/appHeader/templates/appHeader.hbs
@@ -1,7 +1,7 @@
 <div class="appHeader-bg"></div>
 <div class="appHeader-inner clearfix">
   <div class="appHeader-left">
-    <div href="#" class="appHeader-item appHeader-product-name">{{t 'app.productname'}}</div>
+    <div href="#" class="appHeader-item appHeader-product-name">{{constant 'adapt-authoring-core.appName'}}</div>
   </div>
   <div class="appHeader-right">
     <a href="#" class="appHeader-item appHeader-help" data-event="help">

--- a/app/modules/user/less/login.less
+++ b/app/modules/user/less/login.less
@@ -34,7 +34,7 @@
 
   .login-logo {
     height: 123px;
-    background-image: url('assets/adapt-learning-logo-white.png');
+    background-image: @logo-image;
     background-position: center;
     background-repeat: no-repeat;
   }

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -9,6 +9,15 @@ The app name and theme colours are owned by the core config (`adapt-authoring-co
 
 The colours are applied to the LESS at **build time** (via `modifyVars`), so changing one requires a UI rebuild to take effect. Any colour left unset falls back to the default defined in `app/core/less/colours.less`.
 
+### Branding images
+
+Four core config keys point at custom image files (absolute filesystem paths). Each configured file is copied into the build's `css/assets/` directory and referenced in place of the built-in default; a key left unset keeps the built-in. Like the colours, images are baked in at **build time**, so changing one requires a UI rebuild.
+
+- `favicon` — the browser-tab icon (`index`/`loading` pages). Falls back to `favicon.png`.
+- `logo` — the loading-screen and login-screen logo. Falls back to `adapt-learning-logo-outline.png` / `adapt-learning-logo-white.png`.
+- `loginBackground` — the full-screen login/forgot/reset background (LESS `@login-background-image`). Falls back to `login_bg.jpg`.
+- `projectPlaceholder` — the default course thumbnail shown when a course has no hero image (LESS `@default-project-bg`). Falls back to `origami-project.jpg`.
+
 ## Extending the UI
 
 The UI can be extended easily from an Adapt authoring tool module.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,5 +1,14 @@
 # Working with the UI
 
+## Branding & theme
+
+The app name and theme colours are owned by the core config (`adapt-authoring-core.*`), so they have a single, neutral source of truth shared with other modules (e.g. the mailer):
+
+- `appName` — shown in the browser tab and the app header.
+- `primaryColour`, `commitColour`, `chromeColour`, `accentColour` — map onto the editable LESS colours `@primary-color`, `@secondary-color`, `@tertiary-color` and `@quaternary-color` respectively.
+
+The colours are applied to the LESS at **build time** (via `modifyVars`), so changing one requires a UI rebuild to take effect. Any colour left unset falls back to the default defined in `app/core/less/colours.less`.
+
 ## Extending the UI
 
 The UI can be extended easily from an Adapt authoring tool module.

--- a/lib/UiBuild.js
+++ b/lib/UiBuild.js
@@ -8,6 +8,7 @@ import { Gaze } from 'gaze'
 import chalk from 'chalk'
 import JavaScriptTask from './JavaScriptTask.js'
 import { brandColours } from './utils/brandColours.js'
+import { brandImages } from './utils/brandImages.js'
 import { collate } from './utils/collate.js'
 
 class UiBuild {
@@ -63,6 +64,13 @@ class UiBuild {
     this.postBuildHook = new Hook()
 
     this.jsTask = new JavaScriptTask(this.Paths.Output, this.log, this.uiPlugins, path.join(this.app.getConfig('tempDir'), 'ui-build-cache'))
+
+    this.brandImages = brandImages({
+      favicon: this.app.config.get('adapt-authoring-core.favicon'),
+      logo: this.app.config.get('adapt-authoring-core.logo'),
+      loginBackground: this.app.config.get('adapt-authoring-core.loginBackground'),
+      projectPlaceholder: this.app.config.get('adapt-authoring-core.projectPlaceholder')
+    }, this.Paths.OutputDirs.assets)
   }
 
   logCopy (event, dest, src) {
@@ -96,6 +104,28 @@ class UiBuild {
       })
     }))
     await Promise.all(files.map(async ([src, dest]) => fs.cp(src, dest)))
+  }
+
+  async copyBrandImages () {
+    await Promise.all(Object.values(this.brandImages).map(async ({ src, dest }) => {
+      try {
+        await fs.cp(src, dest)
+      } catch (e) {
+        this.log('warn', `could not copy branding image ${src}, falling back to default (${e.code || e.message})`)
+      }
+    }))
+  }
+
+  brandImageVars () {
+    const LESS_VARS = {
+      logo: '@logo-image',
+      loginBackground: '@login-background-image',
+      projectPlaceholder: '@default-project-bg'
+    }
+    return Object.entries(LESS_VARS).reduce((vars, [key, lessVar]) => {
+      if (this.brandImages[key]) vars[lessVar] = `url("${this.brandImages[key].url}")`
+      return vars
+    }, {})
   }
 
   async compileHandlebars () {
@@ -137,14 +167,17 @@ class UiBuild {
         sourceMapURL: 'adapt.css.map'
       }
     }
-    // Core owns the branding colours; bake them into the theme's editable LESS
-    // vars at build time so core is the single source of truth (see docs/ui.md).
-    lessOptions.modifyVars = brandColours({
-      primaryColour: this.app.config.get('adapt-authoring-core.primaryColour'),
-      commitColour: this.app.config.get('adapt-authoring-core.commitColour'),
-      chromeColour: this.app.config.get('adapt-authoring-core.chromeColour'),
-      accentColour: this.app.config.get('adapt-authoring-core.accentColour')
-    })
+    // Core owns the branding colours and images; bake them into the theme's editable
+    // LESS vars at build time so core is the single source of truth (see docs/ui.md).
+    lessOptions.modifyVars = {
+      ...brandColours({
+        primaryColour: this.app.config.get('adapt-authoring-core.primaryColour'),
+        commitColour: this.app.config.get('adapt-authoring-core.commitColour'),
+        chromeColour: this.app.config.get('adapt-authoring-core.chromeColour'),
+        accentColour: this.app.config.get('adapt-authoring-core.accentColour')
+      }),
+      ...this.brandImageVars()
+    }
     const files = await glob(this.Globs.less, { nodir: true, absolute: true })
     const [core, theRest] = files.reduce((sorted, f) => {
       const isCore = f.replaceAll('\\', '/').includes('adapt-authoring-ui/app/core')
@@ -203,6 +236,7 @@ class UiBuild {
 
       await Promise.all([
         this.copyFiles(),
+        this.copyBrandImages(),
         this.compileHandlebars(),
         this.compileLess(),
         this.compileJs()

--- a/lib/UiBuild.js
+++ b/lib/UiBuild.js
@@ -7,6 +7,7 @@ import less from 'less'
 import { Gaze } from 'gaze'
 import chalk from 'chalk'
 import JavaScriptTask from './JavaScriptTask.js'
+import { brandColours } from './utils/brandColours.js'
 import { collate } from './utils/collate.js'
 
 class UiBuild {
@@ -136,6 +137,14 @@ class UiBuild {
         sourceMapURL: 'adapt.css.map'
       }
     }
+    // Core owns the branding colours; bake them into the theme's editable LESS
+    // vars at build time so core is the single source of truth (see docs/ui.md).
+    lessOptions.modifyVars = brandColours({
+      primaryColour: this.app.config.get('adapt-authoring-core.primaryColour'),
+      commitColour: this.app.config.get('adapt-authoring-core.commitColour'),
+      chromeColour: this.app.config.get('adapt-authoring-core.chromeColour'),
+      accentColour: this.app.config.get('adapt-authoring-core.accentColour')
+    })
     const files = await glob(this.Globs.less, { nodir: true, absolute: true })
     const [core, theRest] = files.reduce((sorted, f) => {
       const isCore = f.replaceAll('\\', '/').includes('adapt-authoring-ui/app/core')

--- a/lib/UiModule.js
+++ b/lib/UiModule.js
@@ -1,5 +1,6 @@
 import { AbstractModule, Hook } from 'adapt-authoring-core'
 import path from 'path'
+import { brandImages } from './utils.js'
 
 const CSP_POLICY = [
   "default-src 'self'",
@@ -106,6 +107,12 @@ class UiModule extends AbstractModule {
    * @return {Function} Express handler function
    */
   servePage (pageName) {
+    const images = brandImages({
+      favicon: this.app.config.get('adapt-authoring-core.favicon'),
+      logo: this.app.config.get('adapt-authoring-core.logo')
+    })
+    const favicon = images.favicon?.url ?? '/css/assets/favicon.png'
+    const logo = images.logo?.url ?? '/css/assets/adapt-learning-logo-outline.png'
     return async (req, res, next) => {
       const framework = await this.app.waitForModule('adaptframework')
       res.setHeader('Content-Security-Policy', CSP_POLICY)
@@ -116,6 +123,8 @@ class UiModule extends AbstractModule {
           'adapt-authoring': this.app.pkg.version
         },
         git: { 'adapt-authoring': this.app.git },
+        favicon,
+        logo,
         productName: this.app.config.get('adapt-authoring-core.appName') || this.app.lang.translate(req, 'app.productname')
       })
     }

--- a/lib/UiModule.js
+++ b/lib/UiModule.js
@@ -116,7 +116,7 @@ class UiModule extends AbstractModule {
           'adapt-authoring': this.app.pkg.version
         },
         git: { 'adapt-authoring': this.app.git },
-        productName: this.app.lang.translate(req, 'app.productname')
+        productName: this.app.config.get('adapt-authoring-core.appName') || this.app.lang.translate(req, 'app.productname')
       })
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,2 +1,3 @@
 export { brandColours } from './utils/brandColours.js'
+export { brandImages } from './utils/brandImages.js'
 export { collate } from './utils/collate.js'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,1 +1,2 @@
+export { brandColours } from './utils/brandColours.js'
 export { collate } from './utils/collate.js'

--- a/lib/utils/brandColours.js
+++ b/lib/utils/brandColours.js
@@ -1,0 +1,24 @@
+/**
+ * Maps core's branding colours onto the theme's editable LESS variables for use
+ * as Less `modifyVars`. Colours left unset are omitted, so the defaults defined in
+ * colours.less stand.
+ * @param {Object} colours Branding colours from adapt-authoring-core config
+ * @param {string} [colours.primaryColour]
+ * @param {string} [colours.commitColour]
+ * @param {string} [colours.chromeColour]
+ * @param {string} [colours.accentColour]
+ * @returns {Object} Map of LESS variable name to colour value
+ * @memberof ui
+ */
+export function brandColours (colours = {}) {
+  const LESS_VARS = {
+    primaryColour: '@primary-color',
+    commitColour: '@secondary-color',
+    chromeColour: '@tertiary-color',
+    accentColour: '@quaternary-color'
+  }
+  return Object.entries(LESS_VARS).reduce((vars, [key, lessVar]) => {
+    if (colours[key]) vars[lessVar] = colours[key]
+    return vars
+  }, {})
+}

--- a/lib/utils/brandImages.js
+++ b/lib/utils/brandImages.js
@@ -1,0 +1,34 @@
+import path from 'node:path'
+
+/**
+ * Maps core's branding image config paths to their build destination and served
+ * URL. Each configured image is copied into the UI build's assets dir and referenced
+ * from a Handlebars page var or LESS `modifyVars`. Keys left unset are omitted, so the
+ * built-in defaults stand. The source extension is preserved so the static server sets
+ * the correct MIME type.
+ * @param {Object} images Branding image paths from adapt-authoring-core config
+ * @param {string} [images.favicon]
+ * @param {string} [images.logo]
+ * @param {string} [images.loginBackground]
+ * @param {string} [images.projectPlaceholder]
+ * @param {string} assetsDir Directory the assets are copied into
+ * @param {string} [servedBase] URL base the assets are served from
+ * @returns {Object} Map of config key to `{ src, dest, url }`
+ * @memberof ui
+ */
+export function brandImages (images = {}, assetsDir = '', servedBase = '/css/assets') {
+  const NAMES = {
+    favicon: 'brand-favicon',
+    logo: 'brand-logo',
+    loginBackground: 'brand-login-background',
+    projectPlaceholder: 'brand-project-placeholder'
+  }
+  return Object.entries(NAMES).reduce((out, [key, name]) => {
+    const src = images[key]
+    if (src) {
+      const file = `${name}${path.extname(src)}`
+      out[key] = { src, dest: `${assetsDir}/${file}`, url: `${servedBase}/${file}` }
+    }
+    return out
+  }, {})
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "adapt-authoring-adaptframework": "^3.0.0",
     "adapt-authoring-authored": "^1.4.0",
     "adapt-authoring-content": "^3.0.0",
+    "adapt-authoring-core": "^3.1.0",
     "adapt-authoring-server": "^2.0.0"
   },
   "devDependencies": {

--- a/tests/utils-brandColours.spec.js
+++ b/tests/utils-brandColours.spec.js
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { brandColours } from '../lib/utils/brandColours.js'
+
+describe('brandColours()', () => {
+  const cases = [
+    {
+      name: 'maps each core colour onto its LESS variable',
+      input: { primaryColour: '#1ec0d9', commitColour: '#00dd95', chromeColour: '#263944', accentColour: '#ec4899' },
+      expected: { '@primary-color': '#1ec0d9', '@secondary-color': '#00dd95', '@tertiary-color': '#263944', '@quaternary-color': '#ec4899' }
+    },
+    {
+      name: 'omits colours that are unset',
+      input: { primaryColour: '#1ec0d9' },
+      expected: { '@primary-color': '#1ec0d9' }
+    },
+    {
+      name: 'omits empty-string colours',
+      input: { primaryColour: '', accentColour: '#ec4899' },
+      expected: { '@quaternary-color': '#ec4899' }
+    },
+    { name: 'returns an empty map for no colours', input: {}, expected: {} },
+    { name: 'returns an empty map for no argument', input: undefined, expected: {} }
+  ]
+
+  cases.forEach(({ name, input, expected }) => {
+    it(name, () => {
+      assert.deepEqual(brandColours(input), expected)
+    })
+  })
+
+  it('ignores unknown keys', () => {
+    assert.deepEqual(brandColours({ someOtherColour: '#fff' }), {})
+  })
+})

--- a/tests/utils-brandImages.spec.js
+++ b/tests/utils-brandImages.spec.js
@@ -1,0 +1,54 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { brandImages } from '../lib/utils/brandImages.js'
+
+describe('brandImages()', () => {
+  const assetsDir = '/build/css/assets'
+
+  const cases = [
+    {
+      name: 'maps each configured image to its dest and served URL',
+      input: {
+        favicon: '/etc/brand/icon.svg',
+        logo: '/etc/brand/mark.png',
+        loginBackground: '/etc/brand/bg.jpg',
+        projectPlaceholder: '/etc/brand/tile.png'
+      },
+      expected: {
+        favicon: { src: '/etc/brand/icon.svg', dest: '/build/css/assets/brand-favicon.svg', url: '/css/assets/brand-favicon.svg' },
+        logo: { src: '/etc/brand/mark.png', dest: '/build/css/assets/brand-logo.png', url: '/css/assets/brand-logo.png' },
+        loginBackground: { src: '/etc/brand/bg.jpg', dest: '/build/css/assets/brand-login-background.jpg', url: '/css/assets/brand-login-background.jpg' },
+        projectPlaceholder: { src: '/etc/brand/tile.png', dest: '/build/css/assets/brand-project-placeholder.png', url: '/css/assets/brand-project-placeholder.png' }
+      }
+    },
+    {
+      name: 'omits images that are unset',
+      input: { logo: '/etc/brand/mark.png' },
+      expected: { logo: { src: '/etc/brand/mark.png', dest: '/build/css/assets/brand-logo.png', url: '/css/assets/brand-logo.png' } }
+    },
+    {
+      name: 'omits empty-string images',
+      input: { favicon: '', logo: '/etc/brand/mark.svg' },
+      expected: { logo: { src: '/etc/brand/mark.svg', dest: '/build/css/assets/brand-logo.svg', url: '/css/assets/brand-logo.svg' } }
+    },
+    { name: 'returns an empty map for no images', input: {}, expected: {} },
+    { name: 'returns an empty map for no argument', input: undefined, expected: {} }
+  ]
+
+  cases.forEach(({ name, input, expected }) => {
+    it(name, () => {
+      assert.deepEqual(brandImages(input, assetsDir), expected)
+    })
+  })
+
+  it('honours a custom served base', () => {
+    assert.deepEqual(
+      brandImages({ favicon: '/x/icon.ico' }, '/out/assets', '/static'),
+      { favicon: { src: '/x/icon.ico', dest: '/out/assets/brand-favicon.ico', url: '/static/brand-favicon.ico' } }
+    )
+  })
+
+  it('ignores unknown keys', () => {
+    assert.deepEqual(brandImages({ someOtherImage: '/x/y.png' }, assetsDir), {})
+  })
+})


### PR DESCRIPTION
### Fixes #477

### Update
- App name now sourced from `adapt-authoring-core.appName` (added in adapt-authoring-core#119) for both the browser tab title (`UiModule#servePage`) and the app header, instead of the `app.productname` lang string. Falls back to the lang string if unset.
- Theme colours now sourced from core config and baked into the editable LESS variables at build time via Less `modifyVars`:
  - `primaryColour` → `@primary-color`
  - `commitColour` → `@secondary-color`
  - `chromeColour` → `@tertiary-color`
  - `accentColour` → `@quaternary-color`
- Any colour left unset falls through to the existing default in `colours.less`, so the change is backwards-compatible. As colours are applied at build time, changing one requires a UI rebuild.
- Branding **images** now sourced from core config. Each configured file (an absolute path) is copied into the build's `css/assets/` under a `brand-` prefixed name and referenced in place of the built-in default; any key left unset keeps the built-in, so the change is backwards-compatible. Like the colours, images are baked in at build time, so changing one requires a rebuild.
  - `favicon` → the browser-tab icon in `index`/`loading` (passed to the templates via `servePage`).
  - `logo` → the loading-screen and login-screen logo (`servePage` var + LESS `@logo-image`).
  - `loginBackground` → the full-screen login/forgot/reset background (LESS `@login-background-image`).
  - `projectPlaceholder` → the default course thumbnail when a course has no hero image (LESS `@default-project-bg`).
- Added `adapt-authoring-core@^3.1.0` as a peer dependency, since the feature relies on its branding config schema.

### New
- Added a generic `constant` Handlebars helper for reading a public config value (`Origin.constants[key]`) from a template.

### Testing
- Extracted the core→LESS colour mapping into a pure `lib/utils/brandColours.js` util with a table-driven `tests/utils-brandColours.spec.js` (6 cases, all passing).
- Extracted the core→asset image mapping into a pure `lib/utils/brandImages.js` util with a table-driven `tests/utils-brandImages.spec.js` (7 cases, all passing).
- Verified via a standalone Less render that `modifyVars` overrides both the editable colours and derived values (e.g. `@info-color: lighten(@primary-color, 10%)`), and that the three image LESS vars (`@logo-image`, `@login-background-image`, `@default-project-bg`) resolve to the injected `url(...)` when configured and to the built-in defaults when unset.
- `standard` lint passes on changed `lib/` files.
- Note: a full end-to-end app build wasn't run here (the local umbrella wires a different UI package); verification is the unit tests, the Less render, and the lint above.
