### PR TITLE
Fix: remove _menu from scaffold attribute blacklist (fixes #484)

### DIFF
--- a/app/modules/scaffold/index.js
+++ b/app/modules/scaffold/index.js
@@ -140,7 +140,6 @@ define([
     '_isSelected',
     '_latestTrackingId',
     '_layout',
-    '_menu',
     '_parentId',
     '_sortOrder',
     '_supportedLayout',


### PR DESCRIPTION
Fixes #484

### Fix

Removed `_menu` from `ATTRIBUTE_BLACKLIST` in _app/modules/scaffold/index.js_.

The blacklist is applied globally to all schemas before rendering forms. `_menu` was included to suppress the internal content-object property of the same name, but the name collision also hid any theme schema group named `_menu` (e.g. the Menu colour group in adapt-contrib-vanilla). The `_menu` content-object attribute is already excluded from theme forms by context — it is not present in theme schemas — so the blacklist entry is unnecessary and only causes harm.

### Testing

1. Install adapt-contrib-vanilla v9.37.1 (or any theme with a `_menu` group in _schema/theme.schema.json_).
2. Open the theme editor for a course.
3. Confirm the Menu fieldset is visible and all colour picker fields render correctly.
4. Open the content-object editor and confirm no `_menu` field appears there.

Posted via collaboration with Claude Code