### PR TITLE
Update: use standard tags query for framework-import tag input

### DIFF
--- a/app/modules/frameworkImport/views/frameworkImportView.js
+++ b/app/modules/frameworkImport/views/frameworkImportView.js
@@ -20,7 +20,14 @@ define(function(require){
     postRender: function() {
       // tagging
       this.$('#tags_control').tagsInput({
-        autocomplete_url: 'api/tags/autocomplete',
+        autocomplete_url: 'api/tags/query',
+        autocomplete: {
+          source: (request, response) => {
+            $.post('api/tags/query', { title: { $regex: `.*${request.term}.*`, $options: 'i' } })
+              .done(tags => response(tags.map(t => t.title)))
+              .fail(() => response([]));
+          }
+        },
         onAddTag: this.onAddTag.bind(this),
         onRemoveTag: this.onRemoveTag.bind(this),
         minChars : 3,


### PR DESCRIPTION
### Update
- Repointed the framework-import tag autocomplete from the removed `api/tags/autocomplete` endpoint to the standard `api/tags/query` endpoint, mirroring the existing `scaffoldTagsView` tag input.

Pairs with adapt-security/adapt-authoring-tags#1, which removes the `/autocomplete` endpoint.

### Testing
- Framework-import screen: type ≥3 characters in the tag field, confirm existing tags autocomplete and add/remove still work.