### PR TITLE
Build: ignore @babel major bumps until rollup-plugin-babel supports v8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      # Babel 8 requires @babel/core@^8, but @rollup/plugin-babel (this build's
+      # only Babel entry point) has no release supporting Babel 8, so the upgrade
+      # cannot land. Revisit if @rollup/plugin-babel ships Babel 8 support.
+      - dependency-name: "@babel/*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
### Build
- Configure Dependabot to ignore `@babel/*` major-version bumps.

Babel 8 requires `@babel/core@^8`, but `@rollup/plugin-babel` (the only Babel entry point in this build) has no release supporting Babel 8 — its latest, `7.1.0`, pins `@babel/core@^7`. The full 7→8 set (#479–#483) was therefore unmergeable and has been closed: `@babel/core@8` fails the build (`BABEL_VERSION_UNSUPPORTED`), and the preset/plugin bumps each require `@babel/core@^8`, so no consistent version set both installs and builds.

This stops Dependabot re-raising an upgrade that cannot land. Revisit if `@rollup/plugin-babel` ships Babel 8 support.