### PR TITLE
New: Add access widget for _access sharing (fixes #486)

### DIFF
--- a/app/core/models/courseModel.js
+++ b/app/core/models/courseModel.js
@@ -16,7 +16,9 @@ define(function(require) {
     },
 
     isEditable: function () {
-      return this.get('_isShared') || this.get('createdBy') == Origin.sessionModel.get('id');
+      var access = this.get('_access') || {};
+      var meId = Origin.sessionModel.get('id');
+      return access.public || (access.users || []).includes(meId) || this.get('createdBy') == meId;
     }
   });
 

--- a/app/modules/projects/views/projectView.js
+++ b/app/modules/projects/views/projectView.js
@@ -79,7 +79,8 @@ define(function(require) {
 
     deleteProjectPrompt: function(event) {
       event && event.preventDefault();
-      var isShared = this.model.get('_isShared') || (this.model.get('_shareWithUsers') && this.model.get('_shareWithUsers').length > 0);
+      var access = this.model.get('_access') || {};
+      var isShared = access.public || (access.users && access.users.length > 0);
       Origin.Notify.confirm({
         type: 'warning',
         title: Origin.l10n.t(`${isShared ? 'app.deletesharedproject' : 'app.deleteproject'}`),

--- a/app/modules/scaffold/index.js
+++ b/app/modules/scaffold/index.js
@@ -47,9 +47,13 @@ define([
         return editor;
       }
       var adaptType = item._adapt && item._adapt.inputType;
+      adaptType = typeof adaptType === 'string' ? adaptType : adaptType && adaptType.type;
 
       if (adaptType) {
-        return typeof adaptType === 'string' ? adaptType : adaptType.type;
+        if (Backbone.Form.editors[adaptType]) {
+          return adaptType;
+        }
+        console.warn('Scaffold: no editor registered for _adapt.inputType "' + adaptType + '", falling back to the primitive type editor');
       }
       switch (item.type) {
         case 'array':

--- a/app/modules/scaffold/index.js
+++ b/app/modules/scaffold/index.js
@@ -2,6 +2,7 @@ define([
   'core/origin',
   'core/helpers',
   './backboneFormsOverrides',
+  './views/scaffoldAccessView',
   './views/scaffoldAssetItemView',
   './views/scaffoldAssetView',
   './views/scaffoldCodeEditorView',
@@ -12,7 +13,7 @@ define([
   './views/scaffoldListView',
   './views/scaffoldTagsView',
   './views/scaffoldUsersView'
-], function(Origin, Helpers, Overrides, ScaffoldAssetItemView, ScaffoldAssetView, ScaffoldCodeEditorView, ScaffoldColourPickerView, ScaffoldDisplayTitleView, ScaffoldFileView, ScaffoldItemsModalView, ScaffoldListView, ScaffoldTagsView, ScaffoldUsersView) {
+], function(Origin, Helpers, Overrides, ScaffoldAccessView, ScaffoldAssetItemView, ScaffoldAssetView, ScaffoldCodeEditorView, ScaffoldColourPickerView, ScaffoldDisplayTitleView, ScaffoldFileView, ScaffoldItemsModalView, ScaffoldListView, ScaffoldTagsView, ScaffoldUsersView) {
 
   var Scaffold = {};
   var alternativeModel;
@@ -138,10 +139,12 @@ define([
     '_hasPreview',
     '_id',
     '_isSelected',
+    '_isShared',
     '_latestTrackingId',
     '_layout',
     '_menu',
     '_parentId',
+    '_shareWithUsers',
     '_sortOrder',
     '_supportedLayout',
     '_theme',
@@ -270,6 +273,13 @@ define([
     }
     const query = model.get('_courseId') ? `&_courseId=${model.get('_courseId')}` : '';
     const schema = await $.getJSON(`api/content/schema?_type=${schemaType}${query}`);
+
+    var access = schema.properties && schema.properties._access;
+    if(access) {
+      access._backboneForms = { type: 'Access' };
+      access.title = access.title || Origin.l10n.t('app.scaffold.access.title');
+      access.description = access.description || Origin.l10n.t('app.scaffold.access.help');
+    }
 
     options.model.schema = buildSchema(schema.required, schema.properties);
     options.fieldsets = buildFieldsets(schema.properties, options);

--- a/app/modules/scaffold/index.js
+++ b/app/modules/scaffold/index.js
@@ -46,6 +46,11 @@ define([
       if (editor) {
         return editor;
       }
+      var adaptType = item._adapt && item._adapt.inputType;
+
+      if (adaptType) {
+        return typeof adaptType === 'string' ? adaptType : adaptType.type;
+      }
       switch (item.type) {
         case 'array':
           return 'List';
@@ -273,13 +278,6 @@ define([
     }
     const query = model.get('_courseId') ? `&_courseId=${model.get('_courseId')}` : '';
     const schema = await $.getJSON(`api/content/schema?_type=${schemaType}${query}`);
-
-    var access = schema.properties && schema.properties._access;
-    if(access) {
-      access._backboneForms = { type: 'Access' };
-      access.title = access.title || Origin.l10n.t('app.scaffold.access.title');
-      access.description = access.description || Origin.l10n.t('app.scaffold.access.help');
-    }
 
     options.model.schema = buildSchema(schema.required, schema.properties);
     options.fieldsets = buildFieldsets(schema.properties, options);

--- a/app/modules/scaffold/lang/en.json
+++ b/app/modules/scaffold/lang/en.json
@@ -6,8 +6,6 @@
     "extensions": "Extensions",
     "colourPickerCancel": "Cancel selection",
     "access": {
-      "title": "Access",
-      "help": "Choose who can access this course.",
       "onlyme": "Only me",
       "specific": "Specific people",
       "anyone": "Anyone"

--- a/app/modules/scaffold/lang/en.json
+++ b/app/modules/scaffold/lang/en.json
@@ -4,6 +4,13 @@
     "properties": "Properties",
     "settings": "Settings",
     "extensions": "Extensions",
-    "colourPickerCancel": "Cancel selection"
+    "colourPickerCancel": "Cancel selection",
+    "access": {
+      "title": "Access",
+      "help": "Choose who can access this course.",
+      "onlyme": "Only me",
+      "specific": "Specific people",
+      "anyone": "Anyone"
+    }
   }
 }

--- a/app/modules/scaffold/less/access.less
+++ b/app/modules/scaffold/less/access.less
@@ -1,0 +1,22 @@
+.field[data-type="Access"] {
+  .scaffold-access-tiers {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .scaffold-access-option {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+
+    input { margin-right: 8px; }
+  }
+  .scaffold-access-people {
+    margin-top: 10px;
+
+    .option {
+      .name { font-weight: @font-weight-bold; }
+      .email { margin-left: 5px; }
+    }
+  }
+}

--- a/app/modules/scaffold/views/scaffoldAccessView.js
+++ b/app/modules/scaffold/views/scaffoldAccessView.js
@@ -1,0 +1,155 @@
+define([ 'core/origin' ], function(Origin) {
+  var TIERS = [ 'onlyme', 'specific', 'anyone' ];
+
+  var ScaffoldAccessView = Backbone.Form.editors.Base.extend({
+    tagName: 'div',
+    className: 'scaffold-access',
+    events: {
+      'change .scaffold-access-tier': function(event) {
+        this.setTier(event.target.value);
+        this.trigger('change', this);
+      },
+      'focus': function() { this.trigger('focus', this); },
+      'blur': function() { this.trigger('blur', this); }
+    },
+
+    render: function() {
+      this.deriveFromValue(this.value);
+      this.$el.html(this.template());
+      this.$people = this.$el.find('.scaffold-access-users');
+      this.fetchUsers(this.initSelectize);
+      this.togglePeople();
+      return this;
+    },
+
+    template: function() {
+      var tier = this.tier;
+      var radios = TIERS.map(function(name) {
+        return '<label class="scaffold-access-option">' +
+          '<input type="radio" class="scaffold-access-tier" name="' + this.id + '-tier"' +
+          ' value="' + name + '"' + (name === tier ? ' checked' : '') + '>' +
+          '<span>' + Origin.l10n.t('app.scaffold.access.' + name) + '</span>' +
+          '</label>';
+      }, this).join('');
+      return '<div class="scaffold-access-tiers">' + radios + '</div>' +
+        '<div class="scaffold-access-people">' +
+        '<input class="scaffold-access-users">' +
+        '</div>';
+    },
+
+    renderItem: function(item, escape) {
+      return Handlebars.templates.scaffoldUsersOption({
+        name: item.firstName && item.lastName ? escape(item.firstName + ' ' + item.lastName) : false,
+        email: escape(item.email),
+        disabled: item.disabled
+      });
+    },
+
+    fetchUsers: function(callback) {
+      $.get('api/users')
+        .done(callback.bind(this))
+        .fail(error => Origin.Notify.alert({ type: 'error', text: error }));
+    },
+
+    initSelectize: function(users) {
+      this.$people.val(this.users.join(','));
+
+      var meId = Origin.sessionModel.get('id');
+
+      users.forEach(function(user) {
+        if(user._id === meId) user.disabled = true;
+      });
+
+      this.$people.selectize({
+        labelField: 'email',
+        valueField: '_id',
+        options: users,
+        searchField: [ 'email', 'firstName', 'lastName' ],
+        render: {
+          item: this.renderItem,
+          option: this.renderItem
+        },
+        onChange: () => this.trigger('change', this),
+        onItemRemove: function(value) {
+          if(value !== Origin.sessionModel.get('id')) {
+            return;
+          }
+          Origin.Notify.alert({
+            type: 'warning',
+            text: Origin.l10n.t('app.stopsharingwithyourself')
+          });
+          this.addItem(value, true);
+          this.close();
+        }
+      });
+    },
+
+    deriveFromValue: function(value) {
+      var access = value || {};
+      this.originalAccess = _.extend({}, access);
+
+      var isPublic = access.public;
+      if(isPublic === undefined) isPublic = this.model.get('_isShared') || false;
+
+      var users = access.users;
+      if(users === undefined) users = this.model.get('_shareWithUsers');
+      this.users = (users || []).slice();
+
+      this.tier = isPublic ? 'anyone' : (this.users.length ? 'specific' : 'onlyme');
+    },
+
+    setTier: function(tier) {
+      this.tier = tier;
+      this.togglePeople();
+    },
+
+    togglePeople: function() {
+      this.$el.find('.scaffold-access-people').toggle(this.tier === 'specific');
+    },
+
+    selectedUsers: function() {
+      var selectize = this.$people && this.$people[0] && this.$people[0].selectize;
+      if(selectize) return selectize.getValue();
+      return this.users;
+    },
+
+    getValue: function() {
+      var access = _.omit(this.originalAccess || {}, 'public', 'users');
+      switch(this.tier) {
+        case 'anyone':
+          access.public = true;
+          break;
+        case 'specific':
+          access.public = false;
+          access.users = this.selectedUsers();
+          break;
+        default:
+          access.public = false;
+      }
+      return access;
+    },
+
+    setValue: function(value) {
+      this.deriveFromValue(value);
+      if(!this.$people) return;
+      this.$el.find('.scaffold-access-tier[value="' + this.tier + '"]').prop('checked', true);
+      var selectize = this.$people[0] && this.$people[0].selectize;
+      if(selectize) selectize.setValue(this.users, true);
+      this.togglePeople();
+    },
+
+    focus: function() {
+      if(!this.hasFocus) this.$el.find('input').first().focus();
+    },
+
+    blur: function() {
+      if(this.hasFocus) this.$el.find('input').first().blur();
+    }
+  });
+
+  Origin.on('origin:dataReady', function() {
+    Origin.scaffold.addCustomField('Access', ScaffoldAccessView);
+  });
+
+  return ScaffoldAccessView;
+});


### PR DESCRIPTION
### Fixes #486

### New
- Add an `Access` backbone-forms editor (`app/modules/scaffold/views/scaffoldAccessView.js`) that renders one exclusive-tier sharing control over the flat `_access` object, replacing the legacy `_isShared` / `_shareWithUsers` fields:
  - **Only me** → `{ public: false }`
  - **Specific people** → `{ public: false, users: [...] }` (Selectize people picker over `GET api/users`, reusing the existing `scaffoldUsersOption` template)
  - **Anyone** → `{ public: true }` (clear-on-public: the in-memory people list is cleared; nothing is auto-saved)
- Unknown `_access` keys are preserved on save.
- Tier labels added to `app/modules/scaffold/lang/en.json` (`app.scaffold.access.*`).
- Scope is **public + share-with-users only** — user groups (`_access.groups`) are intentionally out of scope for this UI.

### Update
- `app/modules/scaffold/index.js` `getType` now honours the canonical schema annotation `_adapt.inputType` (in addition to the legacy `_backboneForms`) when resolving an editor. The `_access` field is expected to carry `_adapt.inputType: "Access"` in its served schema — the UI does **not** force a `_backboneForms` type client-side.
- Legacy `_isShared` / `_shareWithUsers` are hidden via `ATTRIBUTE_BLACKLIST` so they don't render alongside the widget during the cutover (the fields stay in the DB, readable, until the later contract step).
- Read-side now reads `_access` instead of the legacy fields: `courseModel.isEditable` (`app/core/models/courseModel.js`) and the shared-project delete prompt (`app/modules/projects/views/projectView.js`).

### Testing
- `npx standard` — passes (`app/` is excluded from the standard config; all editor changes live there).
- `npm test` — 60/60 pass (the suite covers the Node build/`lib` layer, which is untouched).
- The editor seeds tolerantly from the legacy `_isShared` / `_shareWithUsers` fields when `_access` is absent, so it works before and after the backfill migration.
- **Release-gated / not yet end-to-end testable.** This is part of the api#98 step-3 clean cutover: `_access` only appears in the course schema once the enforcement chain lands (adapt-security/adapt-authoring-users#46 `_access.users`, adapt-security/adapt-authoring-content#117 opt-in, adapt-security/adapt-authoring-adaptframework#194 remove legacy paths + backfill). **Do not merge/deploy ahead of that chain** or sharing toggles will write a field nothing reads.

### Depends on (schema)
- The served `_access` schema must annotate the field with `_adapt.inputType: "Access"` (and ideally a `title`/`description` for the section heading and help text). This is the schema-side counterpart to the `getType` change above and should land with the cutover.