### PR TITLE
Fix: exclude updatedBy from scaffold forms (fixes #491)

### DIFF
--- a/app/modules/scaffold/index.js
+++ b/app/modules/scaffold/index.js
@@ -155,6 +155,7 @@ define([
     'themeSettings',
     'themeVariables',
     'updatedAt',
+    'updatedBy',
     'userGroups',
   ];
   function buildSchema(requiredKeys, properties) {


### PR DESCRIPTION
### Fixes #491

### Fix
- Added `updatedBy` to the scaffold `ATTRIBUTE_BLACKLIST`, alongside its sibling authored fields (`createdAt`, `createdBy`, `updatedAt`), so it is excluded from rendered forms.

New-course forms no longer submit an empty `updatedBy` to `/api/content/insertrecursive`, which was failing `isObjectId` schema validation and blocking course creation.
